### PR TITLE
Fix integer division in EV3 motor code

### DIFF
--- a/controller/hardware/actuator/motor/ev3-large-motor.cpp
+++ b/controller/hardware/actuator/motor/ev3-large-motor.cpp
@@ -43,7 +43,7 @@ void EV3LargeMotor::forward(int32_t rotation)
         return;
     }
 
-    float speed = m_motor_speed / 1000.0;
+    float speed = m_motor_speed / 1000.0f;
     drive_motor(speed, rotation);
 }
 
@@ -65,7 +65,7 @@ void EV3LargeMotor::backward(int32_t rotation)
         return;
     }
 
-    float speed = m_motor_speed / 1000.0;
+    float speed = m_motor_speed / 1000.0f;
     drive_motor(-speed, -rotation);
 }
 

--- a/controller/hardware/actuator/motor/ev3-large-motor.cpp
+++ b/controller/hardware/actuator/motor/ev3-large-motor.cpp
@@ -43,7 +43,7 @@ void EV3LargeMotor::forward(int32_t rotation)
         return;
     }
 
-    float speed = m_motor_speed / 1000;
+    float speed = m_motor_speed / 1000.0;
     drive_motor(speed, rotation);
 }
 
@@ -65,7 +65,7 @@ void EV3LargeMotor::backward(int32_t rotation)
         return;
     }
 
-    float speed = m_motor_speed / 1000;
+    float speed = m_motor_speed / 1000.0;
     drive_motor(-speed, -rotation);
 }
 


### PR DESCRIPTION
There was an integer division in the EV3 large motor code that took the speed and divided by 1000. The speed of the motor is an integer, 1000 is also an integer so it did an integer division. If you set the speed to `DEFAULT_MOTOR_SPEED` for example this results in the value `0` instead of the expected `0.5`.

This integer division made it impossible to make the motor move at speeds below the maximum speed.